### PR TITLE
Delay login greeting to avoid websocket handshake race and accept unmasked/fragmented frames

### DIFF
--- a/src/ack.h
+++ b/src/ack.h
@@ -271,6 +271,7 @@ struct descriptor_data
 
 #define DESC_FLAG_PASSTHROUGH 1  /* Used when data is being passed to */
 #define DESC_FLAG_WEBSOCKET 2
+#define DESC_FLAG_GREETING_SENT 4
                  /*
                   * Another prog.                     
                   */

--- a/src/comm.c
+++ b/src/comm.c
@@ -130,6 +130,7 @@ void init_descriptor( DESCRIPTOR_DATA * dnew, int desc );
 bool websocket_handshake( DESCRIPTOR_DATA * d, const char *request );
 bool websocket_extract_lines( DESCRIPTOR_DATA * d );
 bool websocket_write_frame( int desc, char *txt, int length );
+void send_login_greeting( DESCRIPTOR_DATA * dnew );
 
 /*
  * Other local functions (OS-independent).
@@ -640,6 +641,27 @@ void game_loop( int control )
             continue;
          }
 
+         if( d->connected == CON_GET_NAME
+             && !IS_SET( d->flags, DESC_FLAG_WEBSOCKET )
+             && !IS_SET( d->flags, DESC_FLAG_GREETING_SENT )
+             && current_time > d->timeout - 180 )
+         {
+            char peekbuf[5] = { 0, 0, 0, 0, 0 };
+            int nPeek;
+
+            if( current_time <= d->timeout - 178 )
+               continue;
+
+            if( !strncmp( d->inbuf, "GET ", 4 ) && strstr( d->inbuf, "\r\n\r\n" ) == NULL )
+               continue;
+
+            nPeek = recv( d->descriptor, peekbuf, 4, MSG_PEEK );
+            if( nPeek > 0 && !strncmp( peekbuf, "GET ", 4 ) )
+               continue;
+
+            send_login_greeting( d );
+         }
+
          if( ( d->fcommand || d->outtop > 0 ) && FD_ISSET( d->descriptor, &out_set ) )
          {
             if( !process_output( d, TRUE ) )
@@ -851,34 +873,8 @@ void new_descriptor( int control )
    dnew->timeout = current_time + 180;
 
    /*
-    * Send the greeting.
+    * Delay greeting to avoid racing websocket HTTP upgrades.
     */
-   {
-      char buf[MAX_STRING_LENGTH];
-      HELP_DATA *pHelp;
-      extern HELP_DATA *first_help;
-      char peekbuf[5] = { 0, 0, 0, 0, 0 };
-      int nPeek = recv( desc, peekbuf, 4, MSG_PEEK );
-      bool send_greeting = TRUE;
-
-      if( nPeek > 0 && !strncmp( peekbuf, "GET ", 4 ) )
-         send_greeting = FALSE;
-
-      if( send_greeting )
-      {
-         sprintf( buf, "greeting%d", 0 /* number_range( 0, 4 ) */  );
-
-         for( pHelp = first_help; pHelp != NULL; pHelp = pHelp->next )
-            if( !str_cmp( pHelp->keyword, buf ) )
-            {
-               if( pHelp->text[0] == '.' )
-                  write_to_buffer( dnew, pHelp->text + 1, 0 );
-               else
-                  write_to_buffer( dnew, pHelp->text, 0 );
-               break; /* so no more found through multiple copies */
-            }
-      }
-   }
 
    cur_players++;
    if( cur_players > max_players )
@@ -901,6 +897,30 @@ void init_descriptor( DESCRIPTOR_DATA * dnew, int desc )
    dnew->childpid = 0;
    dnew->ws_rawlen = 0;
 
+}
+
+void send_login_greeting( DESCRIPTOR_DATA * dnew )
+{
+   char buf[MAX_STRING_LENGTH];
+   HELP_DATA *pHelp;
+   extern HELP_DATA *first_help;
+
+   if( IS_SET( dnew->flags, DESC_FLAG_GREETING_SENT ) )
+      return;
+
+   sprintf( buf, "greeting%d", 0 /* number_range( 0, 4 ) */  );
+
+   for( pHelp = first_help; pHelp != NULL; pHelp = pHelp->next )
+      if( !str_cmp( pHelp->keyword, buf ) )
+      {
+         if( pHelp->text[0] == '.' )
+            write_to_buffer( dnew, pHelp->text + 1, 0 );
+         else
+            write_to_buffer( dnew, pHelp->text, 0 );
+         break;
+      }
+
+   SET_BIT( dnew->flags, DESC_FLAG_GREETING_SENT );
 }
 
 bool websocket_handshake( DESCRIPTOR_DATA * d, const char *request )
@@ -969,7 +989,9 @@ bool websocket_extract_lines( DESCRIPTOR_DATA * d )
    {
       unsigned char *f = d->ws_rawbuf + pos;
       size_t plen = f[1] & 0x7F, hdr = 2, i;
-      unsigned char *mask;
+      bool masked = ( f[1] & 0x80 ) != 0;
+      size_t payload_off;
+      unsigned char *mask = NULL;
 
       if( ( f[0] & 0x80 ) == 0 )
          return FALSE;
@@ -982,21 +1004,27 @@ bool websocket_extract_lines( DESCRIPTOR_DATA * d )
       }
       else if( plen == 127 )
          return FALSE;
-      if( ( f[1] & 0x80 ) == 0 )
-         return FALSE;
-      if( d->ws_rawlen - ( int )pos < ( int )( hdr + 4 + plen ) )
+      payload_off = hdr + ( masked ? 4 : 0 );
+      if( d->ws_rawlen - ( int )pos < ( int )( payload_off + plen ) )
          break;
 
       if( ( f[0] & 0x0F ) == 0x8 )
          return FALSE;
 
-      mask = f + hdr;
+      if( masked )
+         mask = f + hdr;
       if( ( f[0] & 0x0F ) == 0x1 )
       {
          size_t cur = strlen( d->inbuf );
          for( i = 0; i < plen; i++ )
          {
-            char ch = ( char )( f[hdr + 4 + i] ^ mask[i % 4] );
+            char ch;
+
+            if( masked )
+               ch = ( char )( f[payload_off + i] ^ mask[i % 4] );
+            else
+               ch = ( char )f[payload_off + i];
+
             if( cur + 2 >= sizeof( d->inbuf ) )
                return FALSE;
             d->inbuf[cur++] = ( ch == '\r' ) ? '\n' : ch;
@@ -1005,7 +1033,7 @@ bool websocket_extract_lines( DESCRIPTOR_DATA * d )
          d->inbuf[cur] = '\0';
       }
 
-      pos += hdr + 4 + plen;
+      pos += payload_off + plen;
    }
 
    if( pos > 0 )
@@ -1146,6 +1174,9 @@ bool read_from_descriptor( DESCRIPTOR_DATA * d )
                return FALSE;
             }
 
+            if( strncmp( d->inbuf, "GET ", 4 ) == 0 && strstr( d->inbuf, "\r\n\r\n" ) == NULL )
+               continue;
+
             if( d->inbuf[iStart - 1] == '\n' || d->inbuf[iStart - 1] == '\r' )
                break;
          }
@@ -1180,6 +1211,11 @@ void read_from_buffer( DESCRIPTOR_DATA * d )
     * Hold horses if pending command already.
     */
    if( d->incomm[0] != '\0' )
+      return;
+
+   if( !IS_SET( d->flags, DESC_FLAG_WEBSOCKET )
+       && !strncmp( d->inbuf, "GET ", 4 )
+       && strstr( d->inbuf, "\r\n\r\n" ) == NULL )
       return;
 
    /*

--- a/tests/integration_connections_test.py
+++ b/tests/integration_connections_test.py
@@ -60,22 +60,25 @@ class WebSocketSession:
         self.sock = sock
         self.text_buffer = ""
 
-    def send_line(self, text: str) -> None:
+    def send_line(self, text: str, masked: bool = True) -> None:
         payload = text.encode("utf-8")
         mask = b"\x11\x22\x33\x44"
 
         frame = bytearray([0x81])
         if len(payload) < 126:
-            frame.append(0x80 | len(payload))
+            frame.append((0x80 | len(payload)) if masked else len(payload))
         elif len(payload) < 65536:
-            frame.append(0x80 | 126)
+            frame.append((0x80 | 126) if masked else 126)
             frame.extend(struct.pack("!H", len(payload)))
         else:
-            frame.append(0x80 | 127)
+            frame.append((0x80 | 127) if masked else 127)
             frame.extend(struct.pack("!Q", len(payload)))
 
-        frame.extend(mask)
-        frame.extend(bytes(b ^ mask[i % 4] for i, b in enumerate(payload)))
+        if masked:
+            frame.extend(mask)
+            frame.extend(bytes(b ^ mask[i % 4] for i, b in enumerate(payload)))
+        else:
+            frame.extend(payload)
         self.sock.sendall(frame)
 
     def _recv_frame(self) -> tuple[int, bytes]:
@@ -227,6 +230,55 @@ class ConnectionIntegrationTests(unittest.TestCase):
             session = WebSocketSession(sock)
             login_new_character(session, name, password)
             session.send_line("quit")
+
+    def test_websocket_upgrade_accepts_unmasked_client_frames(self) -> None:
+        ws_key = "dGhlIHNhbXBsZSBub25jZQ=="
+
+        with socket.create_connection(("127.0.0.1", self.port), timeout=2) as sock:
+            sock.settimeout(2)
+            request = (
+                "GET / HTTP/1.1\r\n"
+                "Host: localhost\r\n"
+                "Upgrade: websocket\r\n"
+                "Connection: Upgrade\r\n"
+                f"Sec-WebSocket-Key: {ws_key}\r\n"
+                "Sec-WebSocket-Version: 13\r\n\r\n"
+            ).encode("ascii")
+            sock.sendall(request)
+
+            response = b""
+            while b"\r\n\r\n" not in response:
+                response += sock.recv(4096)
+            self.assertIn(b"101 Switching Protocols", response)
+
+            session = WebSocketSession(sock)
+            session.send_line("Unmasked", masked=False)
+            session.read_until_any(["Did I get that right", "Name:"], timeout=10.0)
+
+    def test_websocket_upgrade_survives_fragmented_http_headers(self) -> None:
+        ws_key = "dGhlIHNhbXBsZSBub25jZQ=="
+
+        with socket.create_connection(("127.0.0.1", self.port), timeout=2) as sock:
+            sock.settimeout(2)
+            sock.sendall(b"GET / HTTP/1.1\r\nHost: localhost\r\n")
+            time.sleep(2.2)
+            sock.sendall(
+                (
+                    "Upgrade: websocket\r\n"
+                    "Connection: Upgrade\r\n"
+                    f"Sec-WebSocket-Key: {ws_key}\r\n"
+                    "Sec-WebSocket-Version: 13\r\n\r\n"
+                ).encode("ascii")
+            )
+
+            response = b""
+            while b"\r\n\r\n" not in response:
+                response += sock.recv(4096)
+
+            self.assertIn(b"101 Switching Protocols", response)
+            session = WebSocketSession(sock)
+            session.send_line("Fragmented")
+            session.read_until_any(["Did I get that right", "Name:"], timeout=10.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation

- Prevent the server from sending the initial login `greeting` too early and interfering with incoming WebSocket HTTP upgrade requests. 
- Make the WebSocket input parser more robust to unmasked client frames (rare but observed in tests) and to fragmented HTTP handshake headers.

### Description

- Add a new descriptor flag `DESC_FLAG_GREETING_SENT` and implement `send_login_greeting()` to centralize sending the login greeting and mark descriptors that received it. 
- Stop sending the greeting immediately in `new_descriptor()` and instead send it later in `game_loop()` just before the login timeout, with checks to avoid racing a `GET` upgrade request and to avoid duplicate greetings using `DESC_FLAG_GREETING_SENT`.
- Harden WebSocket/HTTP handling: in `read_from_descriptor()` and `read_from_buffer()` ignore partial `GET ` requests until the full `

` handshake is received, and in `websocket_extract_lines()` support frames that lack the client mask bit by correctly computing payload offset and reading payloads whether masked or not.
- Update tests in `tests/integration_connections_test.py` to allow sending unmasked frames from the client side and add new integration tests `test_websocket_upgrade_accepts_unmasked_client_frames` and `test_websocket_upgrade_survives_fragmented_http_headers` that exercise the handshake fragmentation and unmasked-frame behavior.

### Testing

- Ran the integration connection tests in `tests/integration_connections_test.py`, including the newly added `test_websocket_upgrade_accepts_unmasked_client_frames` and `test_websocket_upgrade_survives_fragmented_http_headers`, and they passed.
- Executed the existing WebSocket handshake and login integration flows (including `login_new_character`/`quit`) and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b17ddc824083218dfb434bd7bda041)