### PR TITLE
Fix extra newline injection in websocket client input handling

### DIFF
--- a/src/comm.c
+++ b/src/comm.c
@@ -1014,7 +1014,14 @@ bool websocket_extract_lines( DESCRIPTOR_DATA * d )
                return FALSE;
             d->inbuf[cur++] = ( ch == '\r' ) ? '\n' : ch;
          }
-         d->inbuf[cur++] = '\n';
+
+         /*
+          * Browsers commonly send newline-terminated input already.
+          * Only synthesize a line terminator when the frame does not
+          * end with one, otherwise we create an extra empty command.
+          */
+         if( cur == 0 || d->inbuf[cur - 1] != '\n' )
+            d->inbuf[cur++] = '\n';
          d->inbuf[cur] = '\0';
       }
 


### PR DESCRIPTION
### Motivation
- Browser-based WebSocket clients commonly send newline-terminated commands, and the server previously unconditionally appended an extra `\n` after each text frame which produced an empty command following every real command.
- This led to spurious behavior and disconnects during browser-driven sessions, so the server should avoid synthesizing an extra line terminator when one is already present.

### Description
- Modified `src/comm.c` to only append a synthesized newline to `d->inbuf` when the last character of the received frame is not already `\n` and added a short explanatory comment.
- The change keeps existing WebSocket parsing behavior otherwise and prevents injecting empty commands for newline-terminated frames.

### Testing
- Ran `python3 -m unittest tests/integration_connections_test.py -k websocket_upgrade_and_full_login` which passed.
- Ran `python3 -m unittest tests/integration_connections_test.py -k websocket_upgrade_accepts_unmasked_client_frames` which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b18723ad4c8321b315944ea3fb607d)