### PR TITLE
Send login greeting to websocket clients after upgrade

### DIFF
--- a/src/comm.c
+++ b/src/comm.c
@@ -974,7 +974,8 @@ bool websocket_handshake( DESCRIPTOR_DATA * d, const char *request )
    d->ws_rawlen = 0;
    d->inbuf[0] = '\0';
 
-   websocket_write_frame( d->descriptor, "\n\rName: ", 0 );
+   send_login_greeting( d );
+   write_to_buffer( d, "\n\rName: ", 0 );
 
    return TRUE;
 }


### PR DESCRIPTION
### Motivation
- Websocket clients were not receiving the configured login greeting before the `Name:` prompt, causing an inconsistent login experience compared to telnet clients.

### Description
- After a successful websocket handshake the code now calls `send_login_greeting(d)` and uses `write_to_buffer(d, "\n\rName: ", 0)` instead of directly framing the prompt, so the greeting and prompt flow through the normal output pipeline.

### Testing
- Ran the websocket-focused tests with `python -m pytest -q tests/integration_connections_test.py -k websocket` which completed successfully (3 passed, 1 deselected). 
- Ran the full integration suite with `python -m pytest -q tests/integration_connections_test.py` which also completed successfully (4 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b191f6c5c88321857ed37feb8d53a5)