### PR TITLE
Strip carriage return characters from WebSocket frames

### DIFF
--- a/src/comm.c
+++ b/src/comm.c
@@ -2243,6 +2243,19 @@ bool websocket_write_frame( int desc, char *txt, int length )
    if( length <= 0 )
       length = strlen( txt );
 
+   /* Strip all \r characters before sending to websocket client */
+   char *filtered = malloc( length + 1 );
+   if( filtered )
+   {
+      int j = 0;
+      for( int i = 0; i < length; i++ )
+         if( txt[i] != '\r' )
+            filtered[j++] = txt[i];
+      filtered[j] = '\0';
+      length = j;
+      txt = filtered;
+   }
+
    hdr[hlen++] = 0x81;
    if( length < 126 )
       hdr[hlen++] = ( unsigned char )length;
@@ -2259,6 +2272,7 @@ bool websocket_write_frame( int desc, char *txt, int length )
       if( ( nWrite = write( desc, hdr + iStart, nBlock ) ) < 0 )
       {
          perror( "Write_to_descriptor" );
+         free( filtered );
          return FALSE;
       }
    }
@@ -2269,10 +2283,12 @@ bool websocket_write_frame( int desc, char *txt, int length )
       if( ( nWrite = write( desc, txt + iStart, nBlock ) ) < 0 )
       {
          perror( "Write_to_descriptor" );
+         free( filtered );
          return FALSE;
       }
    }
 
+   free( filtered );
    return TRUE;
 }
 


### PR DESCRIPTION
## Summary
Modified the `websocket_write_frame()` function to filter out carriage return (`\r`) characters before sending data to WebSocket clients. This ensures that only line feed (`\n`) characters are used for line endings in WebSocket messages.

## Key Changes
- Added filtering logic to remove all `\r` characters from the message text before transmission
- Dynamically allocates a buffer for the filtered message content
- Updates the message length to reflect the filtered content
- Added proper memory cleanup with `free()` calls in all code paths (normal return and error cases)

## Implementation Details
- The filtering is performed by iterating through the original text and copying only non-carriage-return characters to a newly allocated buffer
- Memory is freed in three locations: on write errors (header and payload) and on successful completion
- The original `txt` pointer is reassigned to point to the filtered buffer for the actual write operations
- If memory allocation fails, the original unfiltered text is used (graceful degradation)

https://claude.ai/code/session_01Pwitp8C5CGGwGZgGf67uUV