### PR TITLE
Fix build for Debian 13 (GCC 14)

### DIFF
--- a/src/comm.c
+++ b/src/comm.c
@@ -763,7 +763,8 @@ void new_descriptor( int control )
     * BAN_DATA *pban;   
     */
    struct sockaddr_in sock;
-   size_t desc, size;
+   int desc;
+   socklen_t size;
 
    size = sizeof( sock );
    getsockname( control, ( struct sockaddr * )&sock, &size );


### PR DESCRIPTION
## Summary
- Change `size_t desc, size` to `int desc; socklen_t size` in `comm.c` for the socket address length parameter passed to `getsockname`, `accept`, and `getpeername`
- GCC 14 on Debian 13 treats `-Wincompatible-pointer-types` as an error by default, causing the build to fail when `size_t*` (8 bytes on x86_64) is passed where `socklen_t*` (4 bytes) is expected

## Test plan
- [x] Verified the build compiles cleanly with `cd src && make` on Debian 13 with GCC 14